### PR TITLE
Tab label number remove bug fix

### DIFF
--- a/_projects/fainting_goats/index.md
+++ b/_projects/fainting_goats/index.md
@@ -6,10 +6,10 @@ authors:
 - Doctor Foster
 tabs:
 - {
-  name: qlcxqfnn,
+  name: tetqfbgs,
   type: html,
   source: _03_data.html,
-  label: 03 Data
+  label:  Data
   }
 ---
 

--- a/_utils/jekyllify.py
+++ b/_utils/jekyllify.py
@@ -97,12 +97,12 @@ def generate_label_from_filename(stem:str) -> str:
     """Given a filename stem (e.g. 03_code-and_data) convert this to a label by:
     
     1. replacing any - or _ characters with spaces
-    2. removing any digits at the start of the filename
-    3. removing any whitespace remaining at the start or end of the name
+    2. removing any whitespace remaining at the start or end of the name
+    3. removing any digits at the start of the filename
     4. converting the name to title case"""
     label = stem.replace("_"," ").replace("-"," ")
-    label = re.sub("^[\d]*","",label)
     label = label.strip()
+    label = re.sub("^[\d]*","",label)
     return label.title()
     
 def generate_title_yaml(dir:Path) -> str:


### PR DESCRIPTION
Minor fix: strip whitespace from tab label before removing leading digits (otherwise they get missed)